### PR TITLE
Move API keys to env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_OMDB_API_KEY=your_omdb_api_key
+VITE_RAPIDAPI_KEY=your_rapidapi_key

--- a/src/components/homepageLayout/Homepage.jsx
+++ b/src/components/homepageLayout/Homepage.jsx
@@ -37,7 +37,7 @@ function Homepage() {
     }
   };
   const getMovie = async () => {
-    const url = `https://www.omdbapi.com/?s=${search}&apikey=ab0f82b6`;
+    const url = `https://www.omdbapi.com/?s=${search}&apikey=${import.meta.env.VITE_OMDB_API_KEY}`;
     const response = await fetch(url);
     const data = await response.json();
     setMovie(data.Search);
@@ -58,7 +58,7 @@ function Homepage() {
     const options = {
       method: "GET",
       headers: {
-        "X-RapidAPI-Key": "fd5f052ca0msh17df6414e90e622p12a46djsndd703d160c9c",
+        "X-RapidAPI-Key": import.meta.env.VITE_RAPIDAPI_KEY,
         "X-RapidAPI-Host": "imdb-top-100-movies.p.rapidapi.com",
       },
     };

--- a/src/components/homepageLayout/MovieDetails.jsx
+++ b/src/components/homepageLayout/MovieDetails.jsx
@@ -17,7 +17,7 @@ function MovieDetails() {
       const arr = checkRef.current || [];
       const movieID = arr[arr.length - 1];
 
-      const url = `https://www.omdbapi.com/?i=${movieID}&plot=full&apikey=ab0f82b6`;
+      const url = `https://www.omdbapi.com/?i=${movieID}&plot=full&apikey=${import.meta.env.VITE_OMDB_API_KEY}`;
       try {
         const response = await fetch(url);
         const data = await response.json();

--- a/src/components/homepageLayout/MyFavouritesPage.jsx
+++ b/src/components/homepageLayout/MyFavouritesPage.jsx
@@ -37,7 +37,7 @@ function MyFavouritesPage() {
           // console.log(docID);
           if (imdbIDs) {
             for (const id of imdbIDs) {
-              const url = `https://www.omdbapi.com/?i=${id}&plot=full&apikey=ab0f82b6`;
+              const url = `https://www.omdbapi.com/?i=${id}&plot=full&apikey=${import.meta.env.VITE_OMDB_API_KEY}`;
               const response = await fetch(url);
               const data = await response.json();
 

--- a/src/components/homepageLayout/TopMovies.jsx
+++ b/src/components/homepageLayout/TopMovies.jsx
@@ -15,7 +15,7 @@ function TopMovies() {
     const options = {
       method: "GET",
       headers: {
-        "X-RapidAPI-Key": "fd5f052ca0msh17df6414e90e622p12a46djsndd703d160c9c",
+        "X-RapidAPI-Key": import.meta.env.VITE_RAPIDAPI_KEY,
         "X-RapidAPI-Host": "imdb-top-100-movies.p.rapidapi.com",
       },
     };


### PR DESCRIPTION
## Summary
- use `import.meta.env` variables instead of hardcoded API keys
- add `.env.example` with API key placeholders

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_683ffae56ebc8327bcaa77f703434d74